### PR TITLE
only scroll for links that exist within #main-nav

### DIFF
--- a/index.html
+++ b/index.html
@@ -294,7 +294,7 @@
 </section>
 <script type="text/javascript" src="js/jquery-2.1.0.min.js"></script>
 <script type="text/javascript">
-$('a').click(function(){
+$('#main-nav a').click(function(){
     $('html, body').animate({
         scrollTop: $( $.attr(this, 'href') ).offset().top
     }, 500);


### PR DESCRIPTION
The event was attached to _all_ links so an error is thrown when clicking on external links. It goes unnoticed because after the error is thrown the `return false` never fires, but it's still unnecessary.
