### PR TITLE
Fix link to hombrew-emacsmacport

### DIFF
--- a/index.html
+++ b/index.html
@@ -145,7 +145,7 @@ title: Emacs is sexy
 	    version though, and it's recommended that you use the latest stable
 	    version. To get the latest and greatest features, there are community built
       packages like <a href="http://emacsformacosx.com/">Emacs For OS
-      X</a> or <a href="https://github.com/railwaycat/emacs-mac-port"
+      X</a> or <a href="https://github.com/railwaycat/homebrew-emacsmacport"
                   title="Emacs Mac Port">Homebrew</a> that are easy to install.
     </p>
     <p>


### PR DESCRIPTION
Looks like this repo was renamed, thus breaking this link