### PR TITLE
Change link to Emacs featured in Tron legacy

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@ title: Emacs is sexy
     </p>
     <p>
       There's a reason why Emacs was
-      <a href="http://jtnimoy.net/workviewer.php?q=178" title="Emacs
+      <a href="http://boingboing.net/2011/04/06/how-emacs-got-into-t.html" title="Emacs
       on Tron Legacy">featured in Tron Legacy</a> - because it's sexy!
     </p>
     <img src="img/emacs.png" alt="Emacs" class="mobile"/>


### PR DESCRIPTION
A while back the original link here started redirecting to 
https://jtnimoy.com/password, I think that linking to this 
boingboing article about how it actually got into the movie,
(as well as some images of the scene in question) is a good alternative.