### PR TITLE
Fix url for emacs bootstrap

### DIFF
--- a/index.html
+++ b/index.html
@@ -333,7 +333,7 @@ title: Emacs is sexy
           <a href="https://github.com/hlissner/doom-emacs">Doom Emacs</a>&nbsp;&mdash; Minimalistic modern Emacs distribution that is light and fast.
         </li>
         <li>
-          <a href="http://www.emacs-bootstrap.com/">Emacs Bootstrap</a>&nbsp;&mdash; Generate on-the-fly Emacs development environment. It lets you select the programming languages you work with and generates enough Emacs config files to get you started.
+          <a href="http://emacs-bootstrap.com/">Emacs Bootstrap</a>&nbsp;&mdash; Generate on-the-fly Emacs development environment. It lets you select the programming languages you work with and generates enough Emacs config files to get you started.
         </li>
       </ul>
     </p>


### PR DESCRIPTION
www.emacs-bootstrap.com directs to a website that says "There's nothing here, yet".
emacs-bootstrap.com fixes the issue.